### PR TITLE
Add guest flow and persist referrals to MongoDB

### DIFF
--- a/back-end/app/database.py
+++ b/back-end/app/database.py
@@ -26,3 +26,7 @@ async def close_db():
 
 def get_db():
     return db
+
+
+def get_referrals_collection():
+    return get_db()["Referrals"]

--- a/back-end/app/models.py
+++ b/back-end/app/models.py
@@ -62,10 +62,20 @@ class TriageResponse(BaseModel):
 # ── Referral ──────────────────────────────────────────────────────────────────
 
 
+class GuestInfo(BaseModel):
+    name: str = Field(min_length=1, max_length=100)
+    email: str = Field(min_length=3, max_length=255)
+    phone: str = Field(min_length=1, max_length=30)
+    date_of_birth: str = Field(alias="dateOfBirth", min_length=1, max_length=20)
+
+    model_config = {"populate_by_name": True}
+
+
 class ReferralCreate(BaseModel):
     hospital_id: str = Field(alias="hospitalId")
     condition_name: str = Field(alias="conditionName")
     severity: Severity
+    guest_info: GuestInfo | None = Field(default=None, alias="guestInfo")
 
     model_config = {"populate_by_name": True}
 
@@ -77,6 +87,8 @@ class Referral(BaseModel):
     severity: Severity
     issued_at: datetime = Field(alias="issuedAt")
     expires_at: datetime = Field(alias="expiresAt")
+    user_id: str | None = Field(default=None, alias="userId")
+    guest_info: GuestInfo | None = Field(default=None, alias="guestInfo")
 
     model_config = {"populate_by_name": True}
 

--- a/back-end/app/models.py
+++ b/back-end/app/models.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class Severity(str, Enum):
@@ -91,6 +91,14 @@ class Referral(BaseModel):
     guest_info: GuestInfo | None = Field(default=None, alias="guestInfo")
 
     model_config = {"populate_by_name": True}
+
+    @field_validator("issued_at", "expires_at", mode="after")
+    @classmethod
+    def ensure_utc(cls, v: datetime) -> datetime:
+        """Normalize naive datetimes from MongoDB to timezone-aware UTC."""
+        if v.tzinfo is None:
+            return v.replace(tzinfo=timezone.utc)
+        return v
 
 
 # ── Auth ──────────────────────────────────────────────────────────────────────

--- a/back-end/app/routers/referrals.py
+++ b/back-end/app/routers/referrals.py
@@ -1,41 +1,78 @@
-from fastapi import APIRouter, HTTPException
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from app.models import Referral, ReferralCreate
+from app.services.auth_service import decode_access_token
 from app.services.triage_engine import (
-    clear_referrals,
     create_referral,
     get_referral_by_token,
-    get_referrals,
+    get_referrals_for_user,
 )
 
 router = APIRouter(prefix="/referrals", tags=["referrals"])
 
+# Optional bearer — allows both authenticated and guest callers
+_optional_bearer = HTTPBearer(auto_error=False)
+
+
+def _extract_user_id(
+    credentials: Optional[HTTPAuthorizationCredentials],
+) -> str | None:
+    """Return the user_id from a valid JWT, or None when no token is provided."""
+    if credentials is None:
+        return None
+    payload = decode_access_token(credentials.credentials)
+    return payload.get("sub")
+
 
 @router.post("", response_model=Referral, status_code=201)
-def issue_referral(body: ReferralCreate):
-    """Generate a new referral token for a hospital + condition."""
+async def issue_referral(
+    body: ReferralCreate,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(_optional_bearer),
+):
+    """Generate a new referral token for a hospital + condition.
+
+    Authenticated users are linked via their user ID.
+    Guests must supply guestInfo in the request body.
+    """
+    user_id = _extract_user_id(credentials)
+
+    if user_id is None and body.guest_info is None:
+        raise HTTPException(
+            status_code=422,
+            detail="Guest users must provide guestInfo (name, email, phone, dateOfBirth).",
+        )
+
     try:
-        return create_referral(body.hospital_id, body.condition_name, body.severity)
+        return await create_referral(
+            hospital_id=body.hospital_id,
+            condition_name=body.condition_name,
+            severity=body.severity,
+            user_id=user_id,
+            guest_info=body.guest_info,
+        )
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
 
 
 @router.get("", response_model=list[Referral])
-def list_referrals():
-    """Return all issued referrals."""
-    return get_referrals()
+async def list_referrals(
+    credentials: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
+):
+    """Return all referrals for the authenticated user."""
+    payload = decode_access_token(credentials.credentials)
+    user_id = payload.get("sub")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid token payload")
+    return await get_referrals_for_user(user_id)
 
 
 @router.get("/{token}", response_model=Referral)
-def lookup_referral(token: str):
-    """Look up a referral by its token."""
-    referral = get_referral_by_token(token)
+async def lookup_referral(token: str):
+    """Look up a referral by its token (public — no auth required)."""
+    referral = await get_referral_by_token(token)
     if referral is None:
         raise HTTPException(status_code=404, detail="Referral not found")
     return referral
-
-
-@router.delete("", status_code=204)
-def delete_all_referrals():
-    """Clear all stored referrals."""
-    clear_referrals()

--- a/back-end/app/routers/referrals.py
+++ b/back-end/app/routers/referrals.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from app.models import Referral, ReferralCreate

--- a/back-end/app/services/triage_engine.py
+++ b/back-end/app/services/triage_engine.py
@@ -1,12 +1,9 @@
 import random
-import string
 from datetime import datetime, timedelta, timezone
 
 from app.data.mock_data import DIRECT_DIAGNOSES, HOSPITALS, SYMPTOM_RULES
-from app.models import Hospital, Referral, ScoredHospital, Severity, TriageCondition
-
-# In-memory referral store (replace with a database later)
-_referrals: list[Referral] = []
+from app.database import get_referrals_collection
+from app.models import GuestInfo, Hospital, Referral, ScoredHospital, Severity, TriageCondition
 
 
 def triage_from_symptoms(symptoms: str) -> TriageCondition | None:
@@ -96,8 +93,14 @@ def generate_referral_token() -> str:
     return f"MR-{'-'.join(segments)}"
 
 
-def create_referral(hospital_id: str, condition_name: str, severity: Severity) -> Referral:
-    """Create and store a new referral."""
+async def create_referral(
+    hospital_id: str,
+    condition_name: str,
+    severity: Severity,
+    user_id: str | None = None,
+    guest_info: GuestInfo | None = None,
+) -> Referral:
+    """Create and persist a new referral to MongoDB."""
     hospital = next((h for h in HOSPITALS if h.id == hospital_id), None)
     if hospital is None:
         raise ValueError(f"Hospital '{hospital_id}' not found")
@@ -110,18 +113,26 @@ def create_referral(hospital_id: str, condition_name: str, severity: Severity) -
         severity=severity,
         issuedAt=now,
         expiresAt=now + timedelta(hours=72),
+        userId=user_id,
+        guestInfo=guest_info,
     )
-    _referrals.append(referral)
+
+    col = get_referrals_collection()
+    await col.insert_one(referral.model_dump(by_alias=True))
     return referral
 
 
-def get_referrals() -> list[Referral]:
-    return list(_referrals)
+async def get_referrals_for_user(user_id: str) -> list[Referral]:
+    """Return all referrals for a given authenticated user."""
+    col = get_referrals_collection()
+    docs = await col.find({"userId": user_id}).sort("issuedAt", -1).to_list(length=200)
+    return [Referral(**doc) for doc in docs]
 
 
-def get_referral_by_token(token: str) -> Referral | None:
-    return next((r for r in _referrals if r.token == token), None)
-
-
-def clear_referrals() -> None:
-    _referrals.clear()
+async def get_referral_by_token(token: str) -> Referral | None:
+    """Look up a referral by its token."""
+    col = get_referrals_collection()
+    doc = await col.find_one({"token": token})
+    if doc is None:
+        return None
+    return Referral(**doc)

--- a/front-end/app/page.tsx
+++ b/front-end/app/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect, useCallback } from "react"
 import {
   Activity,
   Stethoscope,
@@ -25,16 +25,18 @@ import {
   type ReferralRecord,
 } from "@/components/referral-history"
 import { ReferralModal } from "@/components/referral-modal"
+import { GuestInfoForm, type GuestInfo } from "@/components/guest-info-form"
 import type { TriageCondition } from "@/lib/mock-data"
 import {
   triageFromSymptoms,
   matchHospitals,
-  generateReferralToken,
   type ScoredHospital,
 } from "@/lib/triage-engine"
 
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api"
+
 export default function HomePage() {
-  const { user, isAuthenticated, isGuest, isLoading, logout } = useAuth()
+  const { user, token, isAuthenticated, isGuest, isLoading, logout } = useAuth()
   const [activeTab, setActiveTab] = useState("triage")
   const [isProcessing, setIsProcessing] = useState(false)
   const [userInput, setUserInput] = useState("")
@@ -43,8 +45,45 @@ export default function HomePage() {
   const [selectedHospital, setSelectedHospital] =
     useState<ScoredHospital | null>(null)
   const [referralToken, setReferralToken] = useState("")
+  const [referralIssuedAt, setReferralIssuedAt] = useState<Date | undefined>()
+  const [referralExpiresAt, setReferralExpiresAt] = useState<Date | undefined>()
   const [showReferral, setShowReferral] = useState(false)
   const [referrals, setReferrals] = useState<ReferralRecord[]>([])
+
+  // Guest info form state
+  const [showGuestForm, setShowGuestForm] = useState(false)
+  const [pendingHospital, setPendingHospital] = useState<ScoredHospital | null>(
+    null
+  )
+
+  // Fetch referral history for authenticated users
+  const fetchReferrals = useCallback(async () => {
+    if (!isAuthenticated || !token) return
+    try {
+      const res = await fetch(`${API_URL}/referrals`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (res.ok) {
+        const data = await res.json()
+        setReferrals(
+          data.map((r: Record<string, string>) => ({
+            token: r.token,
+            hospitalName: r.hospitalName,
+            conditionName: r.conditionName,
+            severity: r.severity,
+            issuedAt: new Date(r.issuedAt),
+            expiresAt: new Date(r.expiresAt),
+          }))
+        )
+      }
+    } catch {
+      // silently fail — referral history is non-critical
+    }
+  }, [isAuthenticated, token])
+
+  useEffect(() => {
+    fetchReferrals()
+  }, [fetchReferrals])
 
   async function handleSymptomSubmit(input: string) {
     setIsProcessing(true)
@@ -77,23 +116,78 @@ export default function HomePage() {
   }
 
   function handleGenerateReferral(hospital: ScoredHospital) {
-    const token = generateReferralToken()
-    setSelectedHospital(hospital)
-    setReferralToken(token)
-    setShowReferral(true)
+    if (isGuest) {
+      // Guest users need to fill out info first
+      setPendingHospital(hospital)
+      setShowGuestForm(true)
+      return
+    }
+    // Authenticated user — create referral directly
+    createReferralOnServer(hospital, undefined)
+  }
 
-    const now = new Date()
-    setReferrals((prev) => [
-      {
-        token,
-        hospitalName: hospital.name,
-        conditionName: condition?.name ?? "Unknown",
-        severity: condition?.severity ?? "moderate",
-        issuedAt: now,
-        expiresAt: new Date(now.getTime() + 72 * 60 * 60 * 1000),
-      },
-      ...prev,
-    ])
+  async function createReferralOnServer(
+    hospital: ScoredHospital,
+    guestInfo: GuestInfo | undefined
+  ) {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    }
+    if (token) {
+      headers["Authorization"] = `Bearer ${token}`
+    }
+
+    const body: Record<string, unknown> = {
+      hospitalId: hospital.id,
+      conditionName: condition?.name ?? "Unknown",
+      severity: condition?.severity ?? "moderate",
+    }
+    if (guestInfo) {
+      body.guestInfo = guestInfo
+    }
+
+    try {
+      const res = await fetch(`${API_URL}/referrals`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      })
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        toast.error(err.detail || "Failed to create referral")
+        return
+      }
+
+      const referral = await res.json()
+
+      setSelectedHospital(hospital)
+      setReferralToken(referral.token)
+      setReferralIssuedAt(new Date(referral.issuedAt))
+      setReferralExpiresAt(new Date(referral.expiresAt))
+      setShowReferral(true)
+
+      const record: ReferralRecord = {
+        token: referral.token,
+        hospitalName: referral.hospitalName,
+        conditionName: referral.conditionName,
+        severity: referral.severity,
+        issuedAt: new Date(referral.issuedAt),
+        expiresAt: new Date(referral.expiresAt),
+      }
+
+      setReferrals((prev) => [record, ...prev])
+    } catch {
+      toast.error("Network error — could not create referral")
+    }
+  }
+
+  function handleGuestInfoSubmit(info: GuestInfo) {
+    setShowGuestForm(false)
+    if (pendingHospital) {
+      createReferralOnServer(pendingHospital, info)
+      setPendingHospital(null)
+    }
   }
 
   function handleReset() {
@@ -284,6 +378,15 @@ export default function HomePage() {
         hospital={selectedHospital}
         condition={condition}
         referralToken={referralToken}
+        issuedAt={referralIssuedAt}
+        expiresAt={referralExpiresAt}
+      />
+
+      {/* Guest Info Form */}
+      <GuestInfoForm
+        open={showGuestForm}
+        onOpenChange={setShowGuestForm}
+        onSubmit={handleGuestInfoSubmit}
       />
     </div>
   )

--- a/front-end/components/guest-info-form.tsx
+++ b/front-end/components/guest-info-form.tsx
@@ -1,0 +1,138 @@
+"use client"
+
+import { useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { toast } from "sonner"
+
+export interface GuestInfo {
+  name: string
+  email: string
+  phone: string
+  dateOfBirth: string
+}
+
+interface GuestInfoFormProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSubmit: (info: GuestInfo) => void
+}
+
+export function GuestInfoForm({
+  open,
+  onOpenChange,
+  onSubmit,
+}: GuestInfoFormProps) {
+  const [name, setName] = useState("")
+  const [email, setEmail] = useState("")
+  const [phone, setPhone] = useState("")
+  const [dateOfBirth, setDateOfBirth] = useState("")
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+
+    if (!name.trim() || !email.trim() || !phone.trim() || !dateOfBirth) {
+      toast.warning("Please fill out all fields")
+      return
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    if (!emailRegex.test(email)) {
+      toast.warning("Please enter a valid email address")
+      return
+    }
+
+    onSubmit({
+      name: name.trim(),
+      email: email.trim(),
+      phone: phone.trim(),
+      dateOfBirth,
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle style={{ fontFamily: "var(--font-heading)" }}>
+            Your Information
+          </DialogTitle>
+          <DialogDescription>
+            As a guest, please provide your details before generating a
+            referral.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4 pt-2">
+          <div className="space-y-2">
+            <Label htmlFor="guest-name">Full Name</Label>
+            <Input
+              id="guest-name"
+              placeholder="John Doe"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="guest-email">Email</Label>
+            <Input
+              id="guest-email"
+              type="email"
+              placeholder="john@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="guest-phone">Phone Number</Label>
+            <Input
+              id="guest-phone"
+              type="tel"
+              placeholder="+1 (555) 000-0000"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="guest-dob">Date of Birth</Label>
+            <Input
+              id="guest-dob"
+              type="date"
+              value={dateOfBirth}
+              onChange={(e) => setDateOfBirth(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className="flex gap-2 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              className="flex-1"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" className="flex-1">
+              Continue
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/front-end/components/referral-modal.tsx
+++ b/front-end/components/referral-modal.tsx
@@ -21,6 +21,8 @@ interface ReferralModalProps {
   hospital: ScoredHospital | null
   condition: TriageCondition | null
   referralToken: string
+  issuedAt?: Date
+  expiresAt?: Date
 }
 
 export function ReferralModal({
@@ -29,6 +31,8 @@ export function ReferralModal({
   hospital,
   condition,
   referralToken,
+  issuedAt,
+  expiresAt,
 }: ReferralModalProps) {
   const [copied, setCopied] = useState(false)
 
@@ -41,8 +45,8 @@ export function ReferralModal({
     setTimeout(() => setCopied(false), 2000)
   }
 
-  const now = new Date()
-  const expiryDate = new Date(now.getTime() + 72 * 60 * 60 * 1000)
+  const now = issuedAt ?? new Date()
+  const expiryDate = expiresAt ?? new Date(now.getTime() + 72 * 60 * 60 * 1000)
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>


### PR DESCRIPTION
Introduce guest support and replace in-memory referrals with MongoDB persistence. Backend: add get_referrals_collection(), GuestInfo model, and guestInfo/userId fields on Referral models; make triage engine async and persist referrals to the Referrals collection (create_referral, get_referrals_for_user, get_referral_by_token); update routers to accept optional bearer tokens, extract user id, require guestInfo for unauthenticated users, make endpoints async, and remove the old clear/delete flow. Frontend: add GuestInfoForm component and integrate guest flow in page.tsx (show guest form for guests, send guestInfo to POST /referrals, fetch authenticated user's referral history, use API_URL and auth token); update ReferralModal to accept issuedAt/expiresAt. Overall: enables authenticated and guest referral creation and stores referrals in the database.