### PR TITLE
Use MongoDB for hospitals, fix triage back navigation, add Google Map…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ desktop.ini
 dist/
 build/
 *.egg-info/
+tsconfig.tsbuildinfo
 
 # Logs
 *.log

--- a/back-end/app/database.py
+++ b/back-end/app/database.py
@@ -30,3 +30,7 @@ def get_db():
 
 def get_referrals_collection():
     return get_db()["Referrals"]
+
+
+def get_hospitals_collection():
+    return get_db()["Hospitals"]

--- a/back-end/app/routers/hospitals.py
+++ b/back-end/app/routers/hospitals.py
@@ -1,18 +1,31 @@
 from fastapi import APIRouter, HTTPException, Query
 
 from app.data.mock_data import HOSPITALS
+from app.database import get_hospitals_collection
 from app.models import Hospital
 
 router = APIRouter(prefix="/hospitals", tags=["hospitals"])
 
 
+async def _get_hospitals() -> list[Hospital]:
+    """Return hospitals from MongoDB if available, otherwise fall back to mock data."""
+    try:
+        col = get_hospitals_collection()
+        docs = await col.find().to_list(length=200)
+        if docs:
+            return [Hospital(**doc) for doc in docs]
+    except Exception:
+        pass
+    return HOSPITALS
+
+
 @router.get("", response_model=list[Hospital])
-def list_hospitals(
+async def list_hospitals(
     specialty: str | None = Query(default=None, description="Filter by specialty (case-insensitive substring)"),
     emergency: bool | None = Query(default=None, description="Filter by emergency capability"),
 ):
     """Return all hospitals, optionally filtered by specialty or emergency flag."""
-    results = HOSPITALS
+    results = await _get_hospitals()
 
     if specialty is not None:
         spec_lower = specialty.lower()
@@ -25,9 +38,10 @@ def list_hospitals(
 
 
 @router.get("/{hospital_id}", response_model=Hospital)
-def get_hospital(hospital_id: str):
+async def get_hospital(hospital_id: str):
     """Get a single hospital by ID."""
-    hospital = next((h for h in HOSPITALS if h.id == hospital_id), None)
+    all_hospitals = await _get_hospitals()
+    hospital = next((h for h in all_hospitals if h.id == hospital_id), None)
     if hospital is None:
         raise HTTPException(status_code=404, detail="Hospital not found")
     return hospital

--- a/front-end/app/page.tsx
+++ b/front-end/app/page.tsx
@@ -8,6 +8,7 @@ import {
   FileText,
   ShieldCheck,
   RotateCcw,
+  ArrowLeft,
   LogOut,
   User,
 } from "lucide-react"
@@ -198,6 +199,13 @@ export default function HomePage() {
     setReferralToken("")
   }
 
+  function handleBack() {
+    setCondition(null)
+    setHospitals([])
+    setSelectedHospital(null)
+    setReferralToken("")
+  }
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-screen bg-background">
@@ -321,15 +329,26 @@ export default function HomePage() {
                 {/* Left panel: assessment */}
                 <div className="shrink-0 lg:w-80 xl:w-96 border-b lg:border-b-0 lg:border-r border-border p-5 flex flex-col gap-4 overflow-y-auto">
                   <TriageResult condition={condition} userInput={userInput} />
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={handleReset}
-                    className="gap-1.5 self-start text-xs text-muted-foreground hover:text-foreground"
-                  >
-                    <RotateCcw className="w-3.5 h-3.5" />
-                    Start over
-                  </Button>
+                  <div className="flex items-center gap-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleBack}
+                      className="gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+                    >
+                      <ArrowLeft className="w-3.5 h-3.5" />
+                      Back
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleReset}
+                      className="gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+                    >
+                      <RotateCcw className="w-3.5 h-3.5" />
+                      Start over
+                    </Button>
+                  </div>
                 </div>
                 {/* Right panel: hospitals */}
                 <div className="flex-1 min-w-0 min-h-0 p-5">
@@ -346,6 +365,7 @@ export default function HomePage() {
                   <SymptomInput
                     onSubmit={handleSymptomSubmit}
                     isProcessing={isProcessing}
+                    initialValue={userInput}
                   />
                 </div>
               </div>

--- a/front-end/components/hospital-card.tsx
+++ b/front-end/components/hospital-card.tsx
@@ -8,9 +8,11 @@ import {
   Zap,
   FileText,
   CheckCircle2,
+  ExternalLink,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import type { ScoredHospital } from "@/lib/triage-engine"
+import { getGoogleMapsUrl } from "@/lib/utils"
 
 interface HospitalCardProps {
   hospital: ScoredHospital
@@ -102,6 +104,18 @@ export function HospitalCard({
           ))}
         </ul>
       )}
+
+      <div className="flex items-center justify-between gap-2 mb-3">
+        <a
+          href={getGoogleMapsUrl(hospital.name, hospital.address)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+        >
+          <ExternalLink className="w-3 h-3" />
+          View on Google Maps
+        </a>
+      </div>
 
       <Button
         onClick={() => onGenerateReferral(hospital)}

--- a/front-end/components/hospitals-browse.tsx
+++ b/front-end/components/hospitals-browse.tsx
@@ -1,12 +1,33 @@
 "use client"
 
-import { MapPin, Star, BedDouble, Clock, Zap, Search } from "lucide-react"
-import { useState } from "react"
+import { MapPin, Star, BedDouble, Clock, Zap, Search, ExternalLink } from "lucide-react"
+import { useState, useEffect } from "react"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { hospitals } from "@/lib/mock-data"
+import { hospitals as mockHospitals, type Hospital } from "@/lib/mock-data"
+import { getGoogleMapsUrl } from "@/lib/utils"
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api"
 
 export function HospitalsBrowse() {
   const [search, setSearch] = useState("")
+  const [hospitals, setHospitals] = useState<Hospital[]>(mockHospitals)
+
+  useEffect(() => {
+    async function fetchHospitals() {
+      try {
+        const res = await fetch(`${API_URL}/hospitals`)
+        if (res.ok) {
+          const data = await res.json()
+          if (data.length > 0) {
+            setHospitals(data)
+          }
+        }
+      } catch (err) {
+        console.error("Failed to fetch hospitals from API, using mock data:", err)
+      }
+    }
+    fetchHospitals()
+  }, [])
 
   const filtered = hospitals.filter(
     (h) =>
@@ -96,6 +117,16 @@ export function HospitalsBrowse() {
                   {hospital.distance} km
                 </span>
               </div>
+
+              <a
+                href={getGoogleMapsUrl(hospital.name, hospital.address)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+              >
+                <ExternalLink className="w-3 h-3" />
+                View on Google Maps
+              </a>
             </div>
           ))}
 

--- a/front-end/components/symptom-input.tsx
+++ b/front-end/components/symptom-input.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner"
 interface SymptomInputProps {
   onSubmit: (input: string) => void
   isProcessing: boolean
+  initialValue?: string
 }
 
 const EXAMPLES = [
@@ -19,8 +20,8 @@ const EXAMPLES = [
   "Anxiety and trouble sleeping",
 ]
 
-export function SymptomInput({ onSubmit, isProcessing }: SymptomInputProps) {
-  const [input, setInput] = useState("")
+export function SymptomInput({ onSubmit, isProcessing, initialValue = "" }: SymptomInputProps) {
+  const [input, setInput] = useState(initialValue)
   const [isListening, setIsListening] = useState(false)
   const [speechSupported, setSpeechSupported] = useState(false)
   const recognitionRef = useRef<SpeechRecognition | null>(null)

--- a/front-end/lib/utils.ts
+++ b/front-end/lib/utils.ts
@@ -4,3 +4,8 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function getGoogleMapsUrl(name: string, address: string): string {
+  const query = encodeURIComponent(`${name}, ${address}`)
+  return `https://www.google.com/maps/search/?api=1&query=${query}`
+}


### PR DESCRIPTION
…s links (#19)

* Initial plan

* feat: use MongoDB for hospitals, add triage back button, add Google Maps links

- Backend: hospitals router reads from MongoDB Hospitals collection with fallback to mock data
- Backend: added get_hospitals_collection() to database.py
- Frontend: hospitals-browse.tsx fetches from API instead of mock data
- Frontend: added Back button to triage result view to return to symptom input
- Frontend: symptom input preserves user text when navigating back
- Frontend: added Google Maps links to hospital cards in both browse and triage views



* refactor: extract getGoogleMapsUrl to shared utils, add error logging for API fetch



---------