### PR TITLE
Make DB/cache resilient and load .env early

### DIFF
--- a/back-end/app/database.py
+++ b/back-end/app/database.py
@@ -1,10 +1,10 @@
+import logging
 import os
 
 import certifi
-from dotenv import load_dotenv
 from motor.motor_asyncio import AsyncIOMotorClient
 
-load_dotenv()
+logger = logging.getLogger(__name__)
 
 MONGODB_URI = os.getenv("MONGODB_URI", "")
 
@@ -14,8 +14,19 @@ db = None
 
 async def connect_db():
     global client, db
-    client = AsyncIOMotorClient(MONGODB_URI, tlsCAFile=certifi.where())
-    db = client.get_default_database("care")
+    if not MONGODB_URI:
+        logger.warning("MONGODB_URI is not set — database features disabled")
+        return
+    try:
+        client = AsyncIOMotorClient(MONGODB_URI, tlsCAFile=certifi.where())
+        db = client.get_default_database("care")
+        # Verify the connection works
+        await client.admin.command("ping")
+        logger.info("Connected to MongoDB")
+    except Exception:
+        logger.warning("Failed to connect to MongoDB — caching disabled", exc_info=True)
+        client = None
+        db = None
 
 
 async def close_db():
@@ -29,12 +40,15 @@ def get_db():
 
 
 def get_referrals_collection():
-    return get_db()["Referrals"]
+    d = get_db()
+    return d["Referrals"] if d is not None else None
 
 
 def get_diagnosis_cache_collection():
-    return get_db()["DiagnosisCache"]
+    d = get_db()
+    return d["DiagnosisCache"] if d is not None else None
 
 
 def get_hospitals_collection():
-    return get_db()["Hospitals"]
+    d = get_db()
+    return d["Hospitals"] if d is not None else None

--- a/back-end/app/routers/triage.py
+++ b/back-end/app/routers/triage.py
@@ -1,7 +1,11 @@
-from fastapi import APIRouter
+import logging
+
+from fastapi import APIRouter, HTTPException
 
 from app.models import TriageRequest, TriageResponse
 from app.services.triage_engine import triage_from_symptoms_ai
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/triage", tags=["triage"])
 
@@ -13,7 +17,11 @@ async def triage_symptoms(body: TriageRequest):
     Uses OpenAI for high-confidence diagnosis, with a rule-based fallback.
     Results are cached in MongoDB to avoid redundant API calls.
     """
-    condition, hospitals, from_cache = await triage_from_symptoms_ai(body.symptoms)
+    try:
+        condition, hospitals, from_cache = await triage_from_symptoms_ai(body.symptoms)
+    except Exception:
+        logger.exception("Triage processing failed")
+        raise HTTPException(status_code=500, detail="Failed to process symptoms. Please try again.")
 
     if condition is None:
         return TriageResponse(condition=None, hospitals=[])

--- a/back-end/app/services/openai_diagnosis.py
+++ b/back-end/app/services/openai_diagnosis.py
@@ -5,13 +5,10 @@ import os
 import re
 from datetime import datetime, timezone
 
-from dotenv import load_dotenv
 from openai import AsyncOpenAI
 
 from app.database import get_diagnosis_cache_collection
 from app.models import Severity, TriageCondition
-
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 
@@ -108,12 +105,17 @@ async def diagnose_with_openai(symptoms: str) -> TriageCondition | None:
 
 async def get_cached_diagnosis(symptoms: str) -> dict | None:
     """Check MongoDB for a cached diagnosis matching these symptoms."""
-    normalized = _normalize_symptoms(symptoms)
-    symptoms_hash = _hash_symptoms(normalized)
-
-    col = get_diagnosis_cache_collection()
-    doc = await col.find_one({"symptoms_hash": symptoms_hash})
-    return doc
+    try:
+        col = get_diagnosis_cache_collection()
+        if col is None:
+            return None
+        normalized = _normalize_symptoms(symptoms)
+        symptoms_hash = _hash_symptoms(normalized)
+        doc = await col.find_one({"symptoms_hash": symptoms_hash})
+        return doc
+    except Exception:
+        logger.warning("Cache lookup failed — skipping cache", exc_info=True)
+        return None
 
 
 async def cache_diagnosis(
@@ -122,20 +124,24 @@ async def cache_diagnosis(
     hospital_ids: list[str],
 ) -> None:
     """Save a diagnosis and its matched hospital IDs to the cache."""
-    normalized = _normalize_symptoms(symptoms)
-    symptoms_hash = _hash_symptoms(normalized)
-
-    col = get_diagnosis_cache_collection()
-    await col.update_one(
-        {"symptoms_hash": symptoms_hash},
-        {
-            "$set": {
-                "symptoms_hash": symptoms_hash,
-                "symptoms": normalized,
-                "condition": condition.model_dump(),
-                "hospital_ids": hospital_ids,
-                "created_at": datetime.now(timezone.utc),
-            }
-        },
-        upsert=True,
-    )
+    try:
+        col = get_diagnosis_cache_collection()
+        if col is None:
+            return
+        normalized = _normalize_symptoms(symptoms)
+        symptoms_hash = _hash_symptoms(normalized)
+        await col.update_one(
+            {"symptoms_hash": symptoms_hash},
+            {
+                "$set": {
+                    "symptoms_hash": symptoms_hash,
+                    "symptoms": normalized,
+                    "condition": condition.model_dump(),
+                    "hospital_ids": hospital_ids,
+                    "created_at": datetime.now(timezone.utc),
+                }
+            },
+            upsert=True,
+        )
+    except Exception:
+        logger.warning("Failed to write diagnosis cache", exc_info=True)

--- a/back-end/main.py
+++ b/back-end/main.py
@@ -1,4 +1,11 @@
+import os
 from contextlib import asynccontextmanager
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Load .env early, before any app imports that read env vars
+load_dotenv(Path(__file__).resolve().parent / ".env")
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware

--- a/back-end/requirements.txt
+++ b/back-end/requirements.txt
@@ -9,3 +9,4 @@ passlib[bcrypt]>=1.7.4
 python-dotenv>=1.0.0
 googlemaps>=4.10.0
 openai>=1.68.0
+certifi>=2024.0.0


### PR DESCRIPTION
Add robust DB and cache handling: log warnings when MONGODB_URI is missing, verify MongoDB connection with a ping, and fall back to disabled caching on connection errors. Guard collection accessors to return None if DB is unavailable and add exception handling around cache lookups/writes to avoid crashes. Wrap triage endpoint processing in try/except to return a 500 HTTP error on failures. Load .env at application startup (main.py) and remove redundant dotenv calls. Also add certifi to requirements for TLS verification.